### PR TITLE
feat: Remove initial playlist information text

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,12 +26,7 @@
             <img src="http://decor2go.ca/cdn/shop/files/MusicManiaWallpaperMural_219598642_Music_kids_hobby_Modern_Colorful_livingroom.png?v=1715194266" alt="Release Radar" class="playlist-cover-art" id="main-cover-art">
 
             <div class="playlist-info">
-                <p class="playlist-description">Catch all the latest music from artists you follow, plus new singles picked for you. Updates every Friday.</p>
-                <div class="playlist-author">
-                    <i class="material-icons spotify-icon">spotify</i>
-                    <span>Made for You</span>
-                </div>
-                <p class="playlist-duration">Import your music</p>
+                <p class="playlist-duration"></p>
             </div>
 
             <div class="actions-bar">


### PR DESCRIPTION
Removes the static text block containing the playlist description, author, and "Import your music" prompt from the main view.

The change was made by editing `index.html` to remove the unnecessary HTML elements, while preserving the `<p class="playlist-duration">` element so that it can be populated with the song count by the application's JavaScript. This addresses the user's request to remove the text shown in the screenshot without breaking existing functionality.