### PR TITLE
feat: Redesign import button and clean up actions bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,7 @@
             </div>
 
             <div class="actions-bar">
-                <i class="material-icons">check_circle</i>
-                <i class="material-icons">arrow_downward</i>
-                <i class="material-icons">more_horiz</i>
+                <i class="material-icons" id="import-music-btn">more_horiz</i>
                 <div class="play-button-container">
                     <i class="material-icons shuffle-icon">shuffle</i>
                     <a class="btn-floating btn-large waves-effect waves-light green" id="main-play-pause-btn">

--- a/index.tsx
+++ b/index.tsx
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Fix for error on line 121: Cast to HTMLImageElement
     const nowPlayingArt = document.getElementById('now-playing-art') as HTMLImageElement;
     const mainCoverArt = document.getElementById('main-cover-art') as HTMLImageElement;
+    const importMusicBtn = document.getElementById('import-music-btn') as HTMLElement;
     const nowPlayingTitle = document.getElementById('now-playing-title') as HTMLElement;
     const nowPlayingArtist = document.getElementById('now-playing-artist') as HTMLElement;
     const progressBar = document.getElementById('progress-bar') as HTMLElement;
@@ -30,7 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const PLACEHOLDER_COVER_URL = 'http://decor2go.ca/cdn/shop/files/MusicManiaWallpaperMural_219598642_Music_kids_hobby_Modern_Colorful_livingroom.png?v=1715194266';
 
     // --- Event Listeners ---
-    mainCoverArt.addEventListener('click', () => fileInput.click());
+    importMusicBtn.addEventListener('click', () => fileInput.click());
     fileInput.addEventListener('change', handleFileSelect);
 
     mainPlayPauseBtn.addEventListener('click', togglePlayPause);
@@ -112,7 +113,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!trackListEl) return;
         trackListEl.innerHTML = '';
         if (playlist.length === 0) {
-            playlistDurationEl.textContent = 'Import your music';
+            if (playlistDurationEl) playlistDurationEl.textContent = '';
             return;
         }
 

--- a/style.css
+++ b/style.css
@@ -84,8 +84,6 @@ body {
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
     border-radius: 30px;
     margin: 16px auto;
-    position: relative;
-    z-index: 10;
 }
 
 .playlist-info {


### PR DESCRIPTION
This commit implements the user's request to redesign the actions bar and change the music import functionality.

The following changes were made:
- The checkmark and download icons were removed from the actions bar.
- The three-dots icon (`more_horiz`) is now used as the import button, with the ID `import-music-btn`.
- The click event listener for triggering the file import has been moved from the album art to this new import button.
- The "Import your music" text that appeared when the playlist was empty has been removed.
- The unnecessary `z-index` fix on the album art has been reverted from the CSS.